### PR TITLE
fix: 로그인 시 db에서 사용자 정보 반환

### DIFF
--- a/src/main/java/com/madcamp/week2/global/auth/social/kakao/service/CustomKakaoService.java
+++ b/src/main/java/com/madcamp/week2/global/auth/social/kakao/service/CustomKakaoService.java
@@ -38,7 +38,9 @@ public class CustomKakaoService {
 
         String email = kakaoAccount.getEmail();
         String nickname = kakaoAccount.getProfile().getNickname();
-        String profileImg = kakaoAccount.getProfile().getProfile_image_url();
+        KakaoUserInfo.Profile profile = kakaoAccount.getProfile();
+
+        String profileImg = profile.getProfile_image_url() == null ? "" : profile.getProfile_image_url();
         ProfileImg profileImg1 = ProfileImg.builder().originalFileName(profileImg).build();
 
 
@@ -67,12 +69,13 @@ public class CustomKakaoService {
         // 토큰 저장
         saveUserToken(user, jwtToken);
 
+        ProfileImg profileImg2 = user.getProfileImg();
 
         return SocialAuthenticationResponse.builder()
                 .accessToken(jwtToken)
-                .nickname(nickname)
-                .email(email)
-                .profileImg(profileImg)
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .profileImg(profileImg2 == null ? "" : profileImg2.getUploadFileUrl())
                 .isRegistered(isRegistered)
                 .build();
     }


### PR DESCRIPTION
## 변경 사항 요약

: 로그인 시 반환되는 사용자 정보를 수정하였습니다. 

## 변경 사항 상세 내역

: 로그인 시 반환되는 사용자 정보를 카카오에서 받은 정보가 아닌, db와 비교하여 db에 저장되어 있는 정보를 반환하도록 수정하였습니다. 


## 비고 
--