### PR TITLE
프로필 이미지 삭제 기능 구현 및 반환값 수정

### DIFF
--- a/src/main/java/com/madcamp/week2/domain/user/controller/UserController.java
+++ b/src/main/java/com/madcamp/week2/domain/user/controller/UserController.java
@@ -26,6 +26,13 @@ public class UserController {
         return ResponseEntity.ok(modifyUser);
     }
 
+    @DeleteMapping("/delete/profileImg/v1")
+    public ResponseEntity<?> deleteProfileImg(@AuthenticationPrincipal User user) {
+
+        userService.deleteProfileImg(user);
+        return ResponseEntity.ok().build();
+    }
+
     @PostMapping("follow/v1")
     public ResponseEntity<?> followUser(@AuthenticationPrincipal User user, @RequestBody Map<String, String> body) {
 

--- a/src/main/java/com/madcamp/week2/domain/user/entity/User.java
+++ b/src/main/java/com/madcamp/week2/domain/user/entity/User.java
@@ -117,6 +117,6 @@ public class User extends BaseEntity implements UserDetails {
      * @return 프로필 이미지 url
      */
     public String getProfileImgUrl() {
-        return this.profileImg != null ? this.profileImg.getUploadFileUrl() : "";
+        return this.profileImg.getUploadFileUrl();
     }
 }

--- a/src/main/java/com/madcamp/week2/domain/user/service/UserService.java
+++ b/src/main/java/com/madcamp/week2/domain/user/service/UserService.java
@@ -44,6 +44,14 @@ public class UserService {
                 .nickname(foundUser.getNickname())
                 .build();
     }
+정
+    public void deleteProfileImg(User user) {
+        User foundUser = userRepository.findWithProfileImgById(user.getId()).orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+
+        if (foundUser.getProfileImgUrl() != null) {
+            foundUser.deleteProfileImage(awsS3Uploader);
+        }
+    }
 
     public void followUser(User user, String followedEmail) {
         User followingUser = userRepository.findById(user.getId()).orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));

--- a/src/main/java/com/madcamp/week2/global/auth/social/kakao/service/CustomKakaoService.java
+++ b/src/main/java/com/madcamp/week2/global/auth/social/kakao/service/CustomKakaoService.java
@@ -40,7 +40,7 @@ public class CustomKakaoService {
         String nickname = kakaoAccount.getProfile().getNickname();
         KakaoUserInfo.Profile profile = kakaoAccount.getProfile();
 
-        String profileImg = profile.getProfile_image_url() == null ? "" : profile.getProfile_image_url();
+        String profileImg = profile.getProfile_image_url() == null ? null : profile.getProfile_image_url();
         ProfileImg profileImg1 = ProfileImg.builder().originalFileName(profileImg).build();
 
 
@@ -75,7 +75,7 @@ public class CustomKakaoService {
                 .accessToken(jwtToken)
                 .nickname(user.getNickname())
                 .email(user.getEmail())
-                .profileImg(profileImg2 == null ? "" : profileImg2.getUploadFileUrl())
+                .profileImg(profileImg2 == null ? null : profileImg2.getUploadFileUrl())
                 .isRegistered(isRegistered)
                 .build();
     }


### PR DESCRIPTION
## 변경 사항 요약

: 유저의 프로필 이미지 삭제 기능을 구현하고, 프로필 이미지가 존재하지 않을 때 기획에 따라 반환값을 null로 두도록 설정하였습니다. 


## 구현 
<img width="1023" alt="스크린샷 2024-01-08 오후 11 38 12" src="https://github.com/wona825/madcamp_week2/assets/81519167/baf9e1fa-248e-4eb6-bd34-145cb0dcbf08">



## 비고 
--